### PR TITLE
PIT: version in PIT header has to be Odin protocol version

### DIFF
--- a/docs/Odin.md
+++ b/docs/Odin.md
@@ -48,7 +48,7 @@ Read:
 Length is 183 bytes.
 ## Session (0x64)
 ### Begin Session
-Write: `0x64(Session) 0x00(Begin) 0x03(Odin v3)` -or- `0x64(Session) 0x00(Begin) 0x04(Odin v4)` \
+Write: `0x64(Session) 0x00(Begin) <protocol version>(0x00, 0x03, 0x04 or 0x05)`
 Read: `0x64(Session) 0x00(Unknown)`
 
 If Unknown is not 0:

--- a/docs/PIT.md
+++ b/docs/PIT.md
@@ -13,7 +13,8 @@ Also things vary from device to device.
 `0x12349876` is the magic number that is located in first 4 bytes of a PIT file. \
 Skip next 4 bytes, and then we have two 8 chars long strings: `COM_TAR2` and `SDM710`, for example. \
 First is unknown, but the second is probably processor's ID/model, or the bootloader ID. \
-After that we have the version of some sort.
+After that we probably have the Odin protocol version that the PIT was created for. \
+Observed protocol versions (so far) are 0, 3, 4 and 5.
 
 ## Entries
 Entries begin after first 28 bytes. \


### PR DESCRIPTION
And in that case there now exists a fifth version of the Odin protocol.